### PR TITLE
Add map actions for multiple items

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,20 @@ A list can be used as a queue or stack. `enqueueActionTypes` and `pushActionType
     allIds: [],
   },
   addActionTypes = [],
+  addManyActionTypes = [],
   changeActionTypes = [],
+  changeManyActionTypes = [],
   removeActionTypes = [],
+  removeManyActionTypes = [],
   keyGetter = action => action.payload.id,
   itemGetter = action => ({...action.payload}),
   itemModifier = (item, action) => ({...item, ...action.payload}),
+  addChangeItemsGetter = action => action.payload.reduce((result, item) => ({
+    ...result,
+    [item.id]: item
+  }), {}),
+  itemsModifier = (item, newItem) => ({...item, ...newItem}),
+  removeKeysGetter = action => action.payload,
   resetActionTypes = [],
   emptyActionTypes = [],
 }

--- a/src/reducers/__tests__/map.spec.js
+++ b/src/reducers/__tests__/map.spec.js
@@ -3,17 +3,30 @@ import map from '../map';
 const ACTION_TYPE_1 = 'ACTION_TYPE_1';
 
 const key = 'myId';
+const key2 = 'myId2';
 const name = 'myName';
+const name2 = 'myName2';
 const changedName = 'myChangedName';
+const changedName2 = 'myChangedName2';
 
 const item = {
   id: key,
   name: name,
 };
 
+const item2 = {
+  id: key2,
+  name: name2,
+};
+
 const changedItem = {
   id: key,
   name: changedName,
+};
+
+const changedItem2 = {
+  id: key2,
+  name: changedName2,
 };
 
 const map0 = {
@@ -35,6 +48,22 @@ const map1Changed = {
   allIds: [key],
 };
 
+const map2 = {
+  byId: {
+    [key]: {...item},
+    [key2]: {...item2},
+  },
+  allIds: [key, key2],
+};
+
+const map2Changed = {
+  byId: {
+    [key]: {...changedItem},
+    [key2]: {...changedItem2},
+  },
+  allIds: [key, key2],
+};
+
 describe('map', () => {
   it('add item', () => {
     expect(
@@ -45,6 +74,17 @@ describe('map', () => {
         payload: item,
       })
     ).toEqual(map1);
+  });
+
+  it('add many items', () => {
+    expect(
+      map({
+        addManyActionTypes: [ACTION_TYPE_1],
+      })(undefined, {
+        type: ACTION_TYPE_1,
+        payload: [item, item2],
+      })
+    ).toEqual(map2);
   });
 
   it('change item', () => {
@@ -58,6 +98,17 @@ describe('map', () => {
     ).toEqual(map1Changed);
   });
 
+  it('change many items', () => {
+    expect(
+      map({
+        changeManyActionTypes: [ACTION_TYPE_1],
+      })(map2, {
+        type: ACTION_TYPE_1,
+        payload: [changedItem, changedItem2],
+      })
+    ).toEqual(map2Changed);
+  });
+
   it('remove item', () => {
     expect(
       map({
@@ -65,6 +116,17 @@ describe('map', () => {
       })(map1, {
         type: ACTION_TYPE_1,
         payload: {id: key}
+      })
+    ).toEqual(map0);
+  });
+
+  it('remove many items', () => {
+    expect(
+      map({
+        removeManyActionTypes: [ACTION_TYPE_1],
+      })(map2, {
+        type: ACTION_TYPE_1,
+        payload: [key, key2],
       })
     ).toEqual(map0);
   });

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -6,11 +6,20 @@ const empty = {
 export default ({
   initialState = empty,
   addActionTypes = [],
+  addManyActionTypes = [],
   changeActionTypes = [],
+  changeManyActionTypes = [],
   removeActionTypes = [],
+  removeManyActionTypes = [],
   keyGetter = action => action.payload.id,
   itemGetter = action => ({...action.payload}),
   itemModifier = (item, action) => ({...item, ...action.payload}),
+  addChangeItemsGetter = action => action.payload.reduce((result, item) => ({
+    ...result,
+    [item.id]: item
+  }), {}),
+  itemsModifier = (item, newItem) => ({...item, ...newItem}),
+  removeKeysGetter = action => action.payload,
   resetActionTypes = [],
   emptyActionTypes = [],
 }) => (
@@ -20,10 +29,16 @@ export default ({
   const {type} = action;
   if (addActionTypes.includes(type)) {
     return add(state, action, keyGetter, itemGetter);
+  } else if (addManyActionTypes.includes(type)) {
+    return addMany(state, action, addChangeItemsGetter);
   } else if (changeActionTypes.includes(type)) {
     return change(state, action, keyGetter, itemModifier);
+  } else if (changeManyActionTypes.includes(type)) {
+    return changeMany(state, action, addChangeItemsGetter, itemsModifier);
   } else if (removeActionTypes.includes(type)) {
     return remove(state, action, keyGetter);
+  } else if (removeManyActionTypes.includes(type)) {
+    return removeMany(state, action, removeKeysGetter);
   } else if (resetActionTypes.includes(type)) {
     return initialState;
   } else if (emptyActionTypes.includes(type)) {
@@ -33,12 +48,22 @@ export default ({
   }
 };
 
-const add = (state, action, keyGetter, itemGetter) => {
-  const key = keyGetter(action);
+const addItem = (state, key, item) => {
   return {
-    byId: {...state.byId, [key]: itemGetter(action)},
+    byId: {...state.byId, [key]: item},
     allIds: state.allIds.includes(key) ? state.allIds : state.allIds.concat(key),
   };
+};
+
+const add = (state, action, keyGetter, itemGetter) => {
+  return addItem(state, keyGetter(action), itemGetter(action));
+};
+
+const addMany = (state, action, addChangeItemsGetter) => {
+  const items = addChangeItemsGetter(action)
+  return Object.keys(items).reduce((result, key) => {
+    return addItem(result, key, items[key]);
+  }, state);
 };
 
 const change = (state, action, keyGetter, itemModifier) => {
@@ -50,8 +75,18 @@ const change = (state, action, keyGetter, itemModifier) => {
   };
 };
 
-const remove = (state, action, keyGetter) => {
-  const key = keyGetter(action);
+const changeMany = (state, action, addChangeItemsGetter, itemsModifier) => {
+  const items = addChangeItemsGetter(action);
+  return Object.keys(items).reduce((result, key) => {
+    const item = result.byId[key];
+    return item === undefined ? result : {
+      byId: {...result.byId, [key]: itemsModifier(item, items[key])},
+      allIds: result.allIds,
+    };
+  }, state);
+};
+
+const removeItem = (state, key) => {
   const item = state.byId[key];
   if (item === undefined) return state;
   const byId = {...state.byId};
@@ -60,4 +95,12 @@ const remove = (state, action, keyGetter) => {
     byId,
     allIds: state.allIds.filter(x => x !== key),
   };
+};
+
+const remove = (state, action, keyGetter) => {
+  return removeItem(state, keyGetter(action));
+};
+
+const removeMany = (state, action, removeKeysGetter) => {
+  return removeKeysGetter(action).reduce(removeItem, state);
 };


### PR DESCRIPTION
This adds `addMany...` and `removeMany...` actions to `map`. These actions can be used to add multiple items to the map with only one action.

For this, three other options where added:

- `collectionGetter = action => [...action.payload]`
- `collectionItemGetter = item => ({ ...item })`
- `collectionKeyGetter = item => item.id`

Closes https://github.com/adrienjt/redux-data-structures/issues/5.